### PR TITLE
Normalize labPBR Normals to Fix Bright Scaled Objects

### DIFF
--- a/shaders/lib/PBR/labPBR.glsl
+++ b/shaders/lib/PBR/labPBR.glsl
@@ -224,5 +224,5 @@ void getPBR(inout dataPBR material, in int id){
     #endif
 
     // Assign normal and calculate normal strength
-    if(hasFallback) material.normal = mix(TBN[2], TBN * normalMap, NORMAL_STRENGTH);
+    if(hasFallback) material.normal = mix(TBN[2], fastNormalize(TBN * normalMap), NORMAL_STRENGTH);
 }


### PR DESCRIPTION
This change adds fastNormalize when multiplying TBR by normalMap for labPBR materials.

In 1.3.6 and 1.3.7, reflective labPBR materials that are scaled down become extremely bright. I believe this is due to the material normals not being normalized. I do not have experience with shaders so there may be a better method to resolve.

To test I used PhysicsMod and shattered a reflective block with a 'Scale Down' animation which reliably grew too bright as it shrank.