### PR TITLE
Adjust the motion blur technique

### DIFF
--- a/shaders/lib/post/motionBlur.glsl
+++ b/shaders/lib/post/motionBlur.glsl
@@ -1,13 +1,17 @@
 vec3 motionBlur(in vec3 currColor, in float depth, in float dither){
-    vec2 prevPosition = (texCoord.xy - getPrevScreenCoord(texCoord, depth)) * MOTION_BLUR_STRENGTH * 0.2;
+    float counter = 0.0;
+    vec2 doublePixel = 2.0 / vec2(viewWidth, viewHeight);
+
+    vec2 prevPosition = texCoord - getPrevScreenCoord(texCoord, depth);
+    vec2 velocity = prevPosition / (1.0 + length(prevPosition)) * MOTION_BLUR_STRENGTH * 0.02;
 
     // Apply dithering
-    vec2 currScreenPos = texCoord + prevPosition * dither;
-    
-    for(int i = 0; i < 4; i++){
-        currScreenPos += prevPosition;
+    vec2 currScreenPos = texCoord - velocity * (3.5 + dither);
+
+    for(; counter < 9; counter++, currScreenPos += velocity){
+        currScreenPos = clamp(currScreenPos, doublePixel, 1.0 - doublePixel);
         currColor += textureLod(gcolor, currScreenPos, 0).rgb;
     }
 
-    return currColor * 0.2;
+    return currColor /= counter;
 }

--- a/shaders/main/composite2.glsl
+++ b/shaders/main/composite2.glsl
@@ -52,6 +52,9 @@
 
         uniform sampler2D depthtex0;
 
+        uniform float viewWidth;
+        uniform float viewHeight;
+
         #include "/lib/utility/projectionFunctions.glsl"
         #include "/lib/utility/prevProjectionFunctions.glsl"
 


### PR DESCRIPTION
Use motion blurring technique currently used in Complementary Reimagined Shader, which also performs and looks good but doesn't introduce any eye-catching artifacts. Complementary shader license issues require consideration.

Closes #88.